### PR TITLE
Fix: Corrects color picker toggle functionality

### DIFF
--- a/main.js
+++ b/main.js
@@ -1224,24 +1224,6 @@ function setupControls() {
     currentPickedColor = [initialR, initialG, initialB];
     colorPickerInput.value = rgbToHex(initialR, initialG, initialB);
     
-    // Set up current color click handler
-    currentColor.addEventListener('click', () => {
-        if (isRandomColor) {
-            // Switch to custom color mode
-            isRandomColor = false;
-            currentColor.classList.remove('rainbow-bg');
-            currentColor.style.backgroundColor = `rgb(${currentPickedColor[0]}, ${currentPickedColor[1]}, ${currentPickedColor[2]})`;
-            
-            // Open the color picker
-            colorPickerInput.click();
-        } else {
-            // Switch back to random color mode
-            isRandomColor = true;
-            currentColor.classList.add('rainbow-bg');
-            currentColor.style.backgroundColor = '';
-        }
-    });
-    
     // Set up color picker change handler
     colorPickerInput.addEventListener('change', (event) => {
         const hexColor = event.target.value;


### PR DESCRIPTION
The color picker button had two event listeners attached, causing an issue where an attempt to switch from a specific color back to random color mode would be immediately undone.

This was due to both listeners toggling the 'isRandomColor' state. The first listener would set it to random, and the second would immediately set it back to specific.

The fix removes the redundant event listener registration from the `setupControls()` function. The `initializeUI()` function is now the sole place where the event listener for the `currentColor` button is established, ensuring the toggle logic executes only once per click. This allows you to reliably switch back to random color mode.